### PR TITLE
Implement CanCanCan Authorization and User Roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,5 +74,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'rails-controller-testing'
 end
-
+gem 'cancancan'
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -281,6 +282,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise (~> 4.9)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,7 @@
 class CommentsController < ApplicationController
+  load_and_authorize_resource
+  before_action :authenticate_user!
+
   def new
     @comment = Comment.new
     @post = Post.find(params[:post_id])
@@ -11,10 +14,22 @@ class CommentsController < ApplicationController
     @comment = @post.comments.new(comment_params.merge(author: @user))
 
     if @comment.save
-      redirect_to user_post_path(@user, @post), notice: 'Comment submitted.'
+      redirect_to user_post_path(@user, @post), notice: 'Submitted new comment .'
     else
       render :new
     end
+  end
+
+  def destroy
+    @user = current_user
+    @comment = Comment.find(params[:id])
+
+    if @comment.user == @user
+      @comment.destroy
+      flash[:notice] = 'Deleted comment .'
+    end
+
+    redirect_to user_post_path
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,7 +24,7 @@ class CommentsController < ApplicationController
     @user = current_user
     @comment = Comment.find(params[:id])
 
-    if @comment.user == @user
+    if @comment.author == @user
       @comment.destroy
       flash[:notice] = 'Deleted comment .'
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
     flash[:notice] = 'Post deleted.'
     redirect_to user_posts_path(@user)
   end
-  
+
   def post_params
     params.require(:post).permit(:title, :text)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,6 +35,14 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @user = User.find(params[:user_id])
+    @post = Post.find(params[:id])
+    @post.destroy
+    flash[:notice] = 'Post deleted.'
+    redirect_to user_posts_path(@user)
+  end
+  
   def post_params
     params.require(:post).permit(:title, :text)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,14 +21,16 @@ class PostsController < ApplicationController
   end
 
   def create
-    set_current_user
+    @user = User.find(params[:user_id])
     @post = @current_user.posts.build(post_params)
     @post.comments_counter = 0
     @post.likes_counter = 0
 
     if @post.save
-      redirect_to user_post_path(@current_user.id, @post.id), notice: 'Your post was successfully created.'
+      flash[:notice] = 'New post submited.'
+      redirect_to user_post_path(@user, @post)
     else
+      flash[:alert] = 'Something went wrong while submiting post.'
       render :new
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,18 @@
 class PostsController < ApplicationController
+  load_and_authorize_resource
+  before_action :authenticate_user!
+
   def index
     @user = User.find(params[:user_id])
     @posts = @user.posts.includes(:comments)
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.new
+    @post = Post.find params[:id]
+    @posts = Post.all
+    @user = current_user
+    @recent_comments = @post.five_most_recent_comments
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     @users = User.all
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  
+
   def index
     @users = User.all
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Ability
   include CanCan::Ability
 
@@ -23,7 +21,7 @@ class Ability
       can :destroy, Comment do |comment|
         comment.author == user
       end
-      
+
       can :create, Post
       can :create, Comment
       can :read, :all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,32 +11,22 @@ class Ability
       can :update, Post do |post|
         post.author == user
       end
+
       can :destroy, Post do |post|
         post.author == user
       end
-    # Define abilities for the user here. For example:
-    #
-    #   return unless user.present?
-    #   can :read, :all
-    #   return unless user.admin?
-    #   can :manage, :all
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, published: true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+
+      can :update, Comment do |comment|
+        comment.user == user
+      end
+
+      can :destroy, Comment do |comment|
+        comment.user == user
+      end
+      
+      can :create, Post
+      can :create, Comment
+      can :read, :all
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new
+    if user.admin?
+      can :manage, :all
+    else
+      can :update, Post do |post|
+        post.author == user
+      end
+      can :destroy, Post do |post|
+        post.author == user
+      end
+    # Define abilities for the user here. For example:
+    #
+    #   return unless user.present?
+    #   can :read, :all
+    #   return unless user.admin?
+    #   can :manage, :all
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
       end
 
       can :destroy, Comment do |comment|
-        comment.user == user
+        comment.author == user
       end
       
       can :create, Post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
-  has_many :comments
-  has_many :likes
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   belongs_to :author, class_name: 'User'
 
   attribute :title, :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   has_many :posts, foreign_key: :author_id
@@ -11,6 +9,7 @@ class User < ApplicationRecord
   attribute :photo, :string
   attribute :bio, :text
   attribute :posts_counter, :integer, default: 0
+  enum role: %i[user admin]
 
   validates :name, presence: true
   validates :posts_counter, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,7 +1,7 @@
 <div style="margin: 30px">
-  <%= form_with(model: [@post, @comment], url: user_post_comments_path(@post.author, @post), local: true, html: { class: "form" }) do |form| %>
+  <%= form_with(model: [@post, @comment], url: user_post_comments_path(current_user.id, @post), local: true, html: { class: "form" }) do |form| %>
     <div class="mb-3">
-      <%= form.label :text, class: "form-label custom-label" %>
+      <%= form.label :Comment, class: "form-label custom-label" %>
       <%= form.text_area :text, class: "form-control custom-input", style: "height: 120px; width: 300px;" %>
     </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,6 +15,9 @@
       </p>
       <p class="card-text PostTitle">Title: <%= @post.title %></p>
       <p class="card-text">Text: <%= @post.text %></p>
+      <% if @post.author.id == current_user.id || current_user.admin? %>
+        <%= button_to 'Delete Post', user_post_path(@post.author, @post), method: :delete, class: 'btn btn-danger' %>
+      <% end %>
     </div>
   </div>
   <% if @post.comments.any? %>
@@ -24,6 +27,9 @@
           <p class = "m-0 CommentsAuthor"><strong><%= comment.author.name%></strong>:
             <%= comment.text%>
           </p>
+          <% if can? :destroy, comment %>
+            <%= button_to 'Delete', user_post_comment_path(@post.author, @post, comment), method: :delete, class: 'btn btn-light text-danger btn-sm'%>
+          <% end %>
           <p class="card-text">
           <small class="text-muted" style='font-size: 50%;'>
             <%= @post.created_at.strftime("%B %d, %Y, %T") %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,9 +18,11 @@
     <div class="card-body text-Secondary text-bg-light p-3">
       <h5 class="card-title">Bio</h5>
       <p class="card-text"><%= @user.bio%></p>
-      <a href='<%=new_user_post_path(@user.id, @post)%>'>
-        <button type="button" class="btn btn-outline-primary">Create Post</button>
-      </a>
+      <% if @user == current_user %>
+        <a href='<%=new_user_post_path(@user.id, @post)%>'>
+          <button type="button" class="btn btn-outline-primary">Create Post</button>
+        </a>
+      <% end %>
     </div>
   </div>
   <% @recent_posts.each do |post|%>
@@ -34,9 +36,11 @@
         </a>
         <p class="card-text"><%= post.text %></p>
         <div class= "d-flex card-text" style="gap: 10px;">
-          <a href='<%= new_user_post_comment_path(user_id: post.author_id, post_id: post.id)%>' class="btn btn-primary mt-3">
-            <span>Comments</span>
-          </a>
+          <% if @user == current_user %>
+            <a href='<%= new_user_post_comment_path(user_id: post.author_id, post_id: post.id)%>' class="btn btn-primary mt-3">
+              <span>Comments</span>
+            </a>
+          <% end %>
           <a class="btn btn-primary mt-3">
             <%= form_for(post.likes.new, url: user_post_likes_path(post.author, post)) do |f| %>
               <%= f.hidden_field :author_id, value: @current_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,10 @@ Rails.application.routes.draw do
   end
   
   resources :users, only: [:index, :show] do
-    resources :posts, only: [:index, :show, :new, :create] do
-      resources :comments ,only:[:index,:new,:create]
+    # resources :posts, only: [:index, :show, :new, :create] do
+    #   resources :comments ,only:[:index,:new,:create]
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
+      resources :comments ,only:[:index,:new,:create, :destroy]
       resources :likes ,only:[:create]
     end
   end

--- a/db/migrate/20231005120731_add_role_to_users.rb
+++ b/db/migrate/20231005120731_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_04_065940) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_05_120731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_04_065940) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["email"], name: "index_users_on_email"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Dear Reviewer,
This pull request addresses several key requirements for our project related to user roles, authorization, and the use of CanCanCan:

1. **Installed CanCanCan**: We have integrated the CanCanCan gem into our project to enable robust authorization capabilities.

2. **Added 'role' Column to Users Table**: We've created a migration to add a 'role' column to the 'users' table. This allows us to define user roles, with 'admin' as a possible role value.

3. **Post Deleting Authorization**: Users can now delete posts if they are the post authors or if they have an 'admin' role. We've implemented CanCanCan to handle this authorization. The "Delete" button is displayed in the view only for authorized users.

4. **Comment Deleting Authorization**: Similar to post deleting, users can delete comments if they are the comment authors or have an 'admin' role. We've also used CanCanCan for this authorization, ensuring the "Delete" button is visible to authorized users.

### Checklist

- [x] Installed CanCanCan in the project.
- [x] Added 'role' column to the users table using a migration.
- [x] Implemented post deleting functionality with authorization using CanCanCan.
- [x] Implemented comment deleting functionality with authorization using CanCanCan.

## Regards,

@Zafron047 @Mike111222 